### PR TITLE
Added support for complex data type and rearranged command line option for GCC C Extension

### DIFF
--- a/src/CGOptions.cpp
+++ b/src/CGOptions.cpp
@@ -204,6 +204,7 @@ DEFINE_GETTER_SETTER_BOOL(const_struct_union_fields);
 DEFINE_GETTER_SETTER_BOOL(lang_cpp);
 DEFINE_GETTER_SETTER_BOOL(cpp11);
 DEFINE_GETTER_SETTER_BOOL(fast_execution);
+DEFINE_GETTER_SETTER_BOOL(complex);
 //extensions
 DEFINE_GETTER_SETTER_BOOL(computed_goto);
 DEFINE_GETTER_SETTER_BOOL(tm_relaxed);
@@ -318,6 +319,7 @@ CGOptions::set_default_settings(void)
 	use_comma_exprs(true);
 	take_union_field_addr(true);
 	vol_struct_union_fields(true);
+	complex(false);
 	const_struct_union_fields(true);
 	Int128(false);
 	UInt128(false);

--- a/src/CGOptions.h
+++ b/src/CGOptions.h
@@ -269,6 +269,9 @@ public:
 	static bool enable_float(void);
 	static bool enable_float(bool p);
 
+	static bool complex(void);
+        static bool complex(bool p);
+
 	static bool strict_float(void);
 	static bool strict_float(bool p);
 
@@ -579,6 +582,7 @@ private:
         static bool     UInt128_;
 	static bool	double_enable_;
 	static bool	enable_float_;
+	static bool	complex_;
 	static bool	strict_float_;
 	static bool	pointers_;
 	static bool	arrays_;

--- a/src/CVQualifiers.cpp
+++ b/src/CVQualifiers.cpp
@@ -603,6 +603,12 @@ CVQualifiers::output_qualified_type_of_typeof(const Type* t, std::ostream &out) 
 			if (i > 0) out << " ";
 			out << "volatile ";
 		}
+		if(this->is_qualifier_complex()){
+			if (!CGOptions::complex())
+				assert(0);
+			if (i > 0) out << " ";
+			out << "_Complex ";
+		}
 		if (i==0) {
 			out << "typeof(" << this->get_typeof_replace_var() << ")" ;
 			out << " ";
@@ -632,6 +638,12 @@ CVQualifiers::output_qualified_type(const Type* t, std::ostream &out) const
 				assert(0);
 			if (i > 0) out << " ";
 			out << "volatile ";
+		}
+		if(is_qualifier_complex()){
+			if (!CGOptions::complex())
+				assert(0);
+			if (i > 0) out << " ";
+			out << "_Complex ";
 		}
 		if (i==0) {
 			base->Output(out);
@@ -760,4 +772,12 @@ CVQualifiers::set_typeof_replace_var(string global_var_name) const{
 string
 CVQualifiers::get_typeof_replace_var() const{
         return typeof_replace_var;
+}
+void
+CVQualifiers::set_complex(bool complex_value) const{
+	this->is_complex = complex_value;
+}
+bool
+CVQualifiers::is_qualifier_complex() const {
+	return this->is_complex;
 }

--- a/src/CVQualifiers.h
+++ b/src/CVQualifiers.h
@@ -100,7 +100,10 @@ public:
 	void set_typeof_replace_var(string global_var_name) const;
 	string get_typeof_replace_var() const;
 	mutable string typeof_replace_var="";
+	void set_complex(bool complex_value) const;
+	bool is_qualifier_complex() const;
 private:
+	mutable bool is_complex = false;
 	// Type qualifiers.
 	vector<bool> is_consts;
 	vector<bool> is_volatiles;

--- a/src/OutputMgr.cpp
+++ b/src/OutputMgr.cpp
@@ -293,7 +293,9 @@ OutputMgr::OutputHeader(int argc, char *argv[], unsigned long seed)
 		out << "#include <float.h>\n";
 		out << "#include <math.h>\n";
 	}
-
+	if(CGOptions::complex()) {
+		out << "#include <complex.h>\n";
+	}
 	ExtensionMgr::OutputHeader(out);
 
 	out << runtime_include << endl;

--- a/src/RandomProgramGenerator.cpp
+++ b/src/RandomProgramGenerator.cpp
@@ -173,11 +173,11 @@ static void print_help()
 	cout << "  --float | --no-float: enable | disable float (disabled by default)." << endl << endl;
 	cout << "  --main | --nomain: enable | disable to generate main function (enabled by default)." << endl <<  endl;
 	cout << "  --math64 | --no-math64: enable | disable 64-bit math ops (enabled by default)." << endl << endl;
-	cout << "  --loc-labels | --no-loc-labels: enable | disable local labels in program (disabled by default)." << endl << endl;
 	cout << "  --inline-function | --no-inline-function: enable | disable inline attributes on generated functions." << endl << endl;
 	cout << "  --inline-function-prob <num>: set the probability of each function being marked as inline (default is 50)." << endl << endl;
 
-	//extensions 
+	//extensions
+	cout << "  -------------------------------------------GCC C Extensions-----------------------------------------" << endl << endl;
 	cout << "  --computed-goto | --no-computed-goto: enable | disable computed goto extension (disable by default)." << endl << endl;
 	cout << "  --tm-relaxed | --no-tm-relaxed : enable | disable transactional memory __transaction_relaxed extension (disable by default)." << endl << endl;
 	cout << "  --stmt_expr | --no-stmt_expr: enable | disable statement-expression extension. (disable by default)" << endl << endl;
@@ -186,6 +186,8 @@ static void print_help()
         cout << "  --uint128 | --no-uint128: enable | disable generate unsigned __int128 as datatype extension (disabled by default)." << endl << endl;
 	cout << "  --double | --no-double: enable | disable generate double as data type extension (disabled by default)." << endl << endl;
 	cout << "  --complex | --no-complex: enable | disable generate complex as data type extension (disabled by default)." << endl << endl;
+	cout << "  --loc-labels | --no-loc-labels: enable | disable local labels in program (disabled by default)." << endl << endl;
+	cout << "  -----------------------------------------------------------------------------------------------" << endl << endl;
 
 	// numbered controls
 	cout << "  --max-array-dim <num>: limit array dimensions to <num>. (default 3)" << endl << endl;

--- a/src/RandomProgramGenerator.cpp
+++ b/src/RandomProgramGenerator.cpp
@@ -185,6 +185,8 @@ static void print_help()
 	cout << "  --int128 | --no-int128: enable | disable generate__int128 as datatype extension (disabled by default)." << endl << endl;
         cout << "  --uint128 | --no-uint128: enable | disable generate unsigned __int128 as datatype extension (disabled by default)." << endl << endl;
 	cout << "  --double | --no-double: enable | disable generate double as data type extension (disabled by default)." << endl << endl;
+	cout << "  --complex | --no-complex: enable | disable generate complex as data type extension (disabled by default)." << endl << endl;
+
 	// numbered controls
 	cout << "  --max-array-dim <num>: limit array dimensions to <num>. (default 3)" << endl << endl;
 	cout << "  --max-array-len-per-dim <num>: limit array length per dimension to <num> (default 10)." << endl << endl;
@@ -868,6 +870,16 @@ main(int argc, char **argv)
 			continue;
 		}
 
+		
+		if (strcmp (argv[i], "--complex") == 0) {
+                        CGOptions::complex(true);
+                        continue;
+                }
+
+                if (strcmp (argv[i], "--no-complex") == 0) {
+                        CGOptions::complex(false);
+                        continue;
+                }
 
 		if (strcmp (argv[i], "--float") == 0) {
 			CGOptions::enable_float(true);

--- a/src/VariableSelector.h
+++ b/src/VariableSelector.h
@@ -151,7 +151,8 @@ private:
 
 	static Variable * create_and_initialize(Effect::Access access, const CGContext &cg_context, const Type* t,
 					const CVQualifiers* qfer, Block *blk, std::string name);
-
+	static Variable * create_and_initialize_complex (Effect::Access access, const CGContext &cg_context, const Type* t,
+					const CVQualifiers* qfer, Block *blk, std::string name);
 	// all variables generated
 	static vector<Variable*> AllVars;
 


### PR DESCRIPTION
This commit contains -
1. Added support for complex data type(only global)
2. Rearranged command line options for GCC C Extensions 